### PR TITLE
[PR] Impl basic functionality for LPS project on original Tiled

### DIFF
--- a/src/libtiled/properties.cpp
+++ b/src/libtiled/properties.cpp
@@ -47,6 +47,7 @@ QString FilePath::toString(const FilePath &path)
 FilePath FilePath::fromString(const QString &string)
 {
     return { Tiled::toUrl(string) };
+//    return {QUrl(string)};
 }
 
 
@@ -305,7 +306,7 @@ ExportValue ExportContext::toExportValue(const QVariant &value) const
         exportValue.value = color.isValid() ? color.name(QColor::HexArgb) : QString();
     } else if (metaType == filePathTypeId()) {
         const auto filePath = value.value<FilePath>();
-        exportValue.value = toFileReference(filePath.url, mPath);
+        exportValue.value = toFileReference(filePath.url);
     } else if (metaType == objectRefTypeId()) {
         exportValue.value = ObjectRef::toInt(value.value<ObjectRef>());
     } else {

--- a/src/libtiled/tiled.cpp
+++ b/src/libtiled/tiled.cpp
@@ -92,7 +92,7 @@ QString Tiled::toFileReference(const QUrl &url, const QString &path)
     return url.toString();
 }
 
-QUrl Tiled::toUrl(const QString &filePathOrUrl, const QString &path)
+QUrl Tiled::toUrl(const QString &filePathOrUrl, const QString &path, const QString& projectFilePath)
 {
     if (filePathOrUrl.isEmpty())
         return QUrl();
@@ -106,6 +106,10 @@ QUrl Tiled::toUrl(const QString &filePathOrUrl, const QString &path)
 
     QString filePath = filePathOrUrl;
 
+    if (!path.isEmpty() && projectFilePath.isEmpty()) {
+        return QUrl(filePath);
+    }
+
     // Resolve possible relative file reference
     if (!path.isEmpty())
         filePath = QDir::cleanPath(QDir(path).filePath(filePath));
@@ -113,7 +117,19 @@ QUrl Tiled::toUrl(const QString &filePathOrUrl, const QString &path)
     if (filePath.startsWith(QLatin1String(":/")))
         return QUrl(QLatin1String("qrc") + filePath);
 
-    return QUrl::fromLocalFile(filePath);
+    if (projectFilePath.isEmpty()) {
+        return QUrl::fromLocalFile(filePath);
+    }
+    else {
+        QFileInfo projectFile(projectFilePath);
+        QFileInfo file(filePath);
+        QString pathRelative = filePathRelativeTo(projectFile.absoluteDir(), file.absoluteFilePath());
+        if (file.isDir()) {
+            pathRelative += QStringLiteral("/");
+        }
+
+        return QUrl(pathRelative);
+    }
 }
 
 /*

--- a/src/libtiled/tiled.h
+++ b/src/libtiled/tiled.h
@@ -92,7 +92,7 @@ inline QPointF alignmentOffset(const QRectF &r, Alignment alignment)
 { return alignmentOffset(r.size(), alignment); }
 
 TILEDSHARED_EXPORT QString toFileReference(const QUrl &url, const QString &path = QString());
-TILEDSHARED_EXPORT QUrl toUrl(const QString &filePathOrUrl, const QString &path = QString());
+TILEDSHARED_EXPORT QUrl toUrl(const QString &filePathOrUrl, const QString &path = QString(), const QString& projectFilePath = QString());
 TILEDSHARED_EXPORT QString urlToLocalFileOrQrc(const QUrl &url);
 TILEDSHARED_EXPORT QString filePathRelativeTo(const QDir &dir, const QString &filePath);
 

--- a/src/tiled/fileedit.cpp
+++ b/src/tiled/fileedit.cpp
@@ -71,7 +71,6 @@ FileEdit::FileEdit(QWidget *parent)
 
 void FileEdit::setFileUrl(const QUrl &url)
 {
-    qDebug() << "[setFileUrl]" << url.path();
     if (mLineEdit->text() != url.path())
         mLineEdit->setText(url.path());
 }

--- a/src/tiled/project.cpp
+++ b/src/tiled/project.cpp
@@ -81,7 +81,7 @@ bool Project::save(const QString &fileName)
         { QStringLiteral("folders"), folders },
         { QStringLiteral("extensionsPath"), relative(dir, extensionsPath) },
         { QStringLiteral("automappingRulesFile"), dir.relativeFilePath(mAutomappingRulesFile) },
-        { QStringLiteral("scriptRootPath"), relative(dir, mScriptRootPath)},
+//        { QStringLiteral("scriptRootPath"), relative(dir, mScriptRootPath)},
         { QStringLiteral("commands"), commands },
     };
 
@@ -124,7 +124,7 @@ bool Project::load(const QString &fileName)
     mExtensionsPath = absolute(dir, project.value(QLatin1String("extensionsPath")).toString(QLatin1String("extensions")));
     mObjectTypesFile = absolute(dir, project.value(QLatin1String("objectTypesFile")).toString());
     mAutomappingRulesFile = absolute(dir, project.value(QLatin1String("automappingRulesFile")).toString());
-    mScriptRootPath = absolute(dir, project.value(QLatin1String("scriptRootPath")).toString());
+//    mScriptRootPath = absolute(dir, project.value(QLatin1String("scriptRootPath")).toString());
 
     mPropertyTypes->loadFromJson(project.value(QLatin1String("propertyTypes")).toArray(), dir.path());
 

--- a/src/tiled/project.h
+++ b/src/tiled/project.h
@@ -51,7 +51,7 @@ public:
     QString mExtensionsPath;
     QString mObjectTypesFile;
     QString mAutomappingRulesFile;
-    QString mScriptRootPath;
+//    QString mScriptRootPath;
     QVector<Command> mCommands;
     CompatibilityVersion mCompatibilityVersion = Tiled_Latest;
 

--- a/src/tiled/projectpropertiesdialog.cpp
+++ b/src/tiled/projectpropertiesdialog.cpp
@@ -68,11 +68,11 @@ ProjectPropertiesDialog::ProjectPropertiesDialog(Project &project, QWidget *pare
     mAutomappingRulesFileProperty->setValue(project.mAutomappingRulesFile);
     mAutomappingRulesFileProperty->setAttribute(QStringLiteral("filter"), helper.filter());
 
-    QString ruleDirFilter = QCoreApplication::translate("File Types", "Directory");
-    FormatHelper<MapFormat> pathDirHelper(FileFormat::ReadWrite, std::move(ruleFileFilter));
-    mFileScriptRootPathProperty = variantPropertyManager->addProperty(filePathTypeId(), tr("Script Root Directory"));
-    mFileScriptRootPathProperty->setValue(project.mScriptRootPath);
-    mFileScriptRootPathProperty->setAttribute(QStringLiteral("directory"), true);
+//    QString ruleDirFilter = QCoreApplication::translate("File Types", "Directory");
+//    FormatHelper<MapFormat> pathDirHelper(FileFormat::ReadWrite, std::move(ruleFileFilter));
+//    mFileScriptRootPathProperty = variantPropertyManager->addProperty(filePathTypeId(), tr("Script Root Directory"));
+//    mFileScriptRootPathProperty->setValue(project.mScriptRootPath);
+//    mFileScriptRootPathProperty->setAttribute(QStringLiteral("directory"), true);
 
     auto generalGroupProperty = groupPropertyManager->addProperty(tr("General"));
     generalGroupProperty->addSubProperty(mCompatibilityVersionProperty);
@@ -80,7 +80,7 @@ ProjectPropertiesDialog::ProjectPropertiesDialog(Project &project, QWidget *pare
     auto filesGroupProperty = groupPropertyManager->addProperty(tr("Paths && Files"));
     filesGroupProperty->addSubProperty(mExtensionPathProperty);
     filesGroupProperty->addSubProperty(mAutomappingRulesFileProperty);
-    filesGroupProperty->addSubProperty(mFileScriptRootPathProperty);
+//    filesGroupProperty->addSubProperty(mFileScriptRootPathProperty);
 
     ui->propertyBrowser->addProperty(generalGroupProperty);
     ui->propertyBrowser->addProperty(filesGroupProperty);
@@ -96,7 +96,7 @@ void ProjectPropertiesDialog::accept()
     mProject.mCompatibilityVersion = mVersions.at(mCompatibilityVersionProperty->value().toInt());
     mProject.mExtensionsPath = mExtensionPathProperty->value().toString();
     mProject.mAutomappingRulesFile = mAutomappingRulesFileProperty->value().toString();
-    mProject.mScriptRootPath = mFileScriptRootPathProperty->value().toString();
+//    mProject.mScriptRootPath = mFileScriptRootPathProperty->value().toString();
 
     QDialog::accept();
 }

--- a/src/tiled/projectpropertiesdialog.h
+++ b/src/tiled/projectpropertiesdialog.h
@@ -52,7 +52,7 @@ private:
     QtVariantProperty *mCompatibilityVersionProperty;
     QtVariantProperty *mExtensionPathProperty;
     QtVariantProperty *mAutomappingRulesFileProperty;
-    QtVariantProperty *mFileScriptRootPathProperty;
+//    QtVariantProperty *mFileScriptRootPathProperty;
 };
 
 } // namespace Tiled

--- a/src/tiled/varianteditorfactory.cpp
+++ b/src/tiled/varianteditorfactory.cpp
@@ -110,6 +110,7 @@ QWidget *VariantEditorFactory::createEditor(QtVariantPropertyManager *manager,
     if (type == filePathTypeId()) {
         auto fileEdit = new FileEdit(parent);
         FilePath filePath = manager->value(property).value<FilePath>();
+        qDebug() << "[Create Editor]" << filePath.url.path() << "," << filePath.url.url();
         fileEdit->setFileUrl(filePath.url);
         fileEdit->setFilter(manager->attributeValue(property, QLatin1String("filter")).toString());
         fileEdit->setIsDirectory(manager->attributeValue(property, QLatin1String("directory")).toBool());


### PR DESCRIPTION
This PR has completed features as follow:

1. Json5 support for Tiled.
2. Directly drag/drop file to fill fileedit's path widget.
3. Export filepath to file with relative path instead of absolute path.
4. Event layer can only be created under Event Layers group.
5. Draw layer can only be created under Render Layers group.